### PR TITLE
python3 compatible

### DIFF
--- a/MPIDriver.py
+++ b/MPIDriver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ### This script creates an MPIManager object and launches distributed training.
 

--- a/mpi_learn/mpi/process.py
+++ b/mpi_learn/mpi/process.py
@@ -118,7 +118,7 @@ class MPIProcess(object):
         """Display metrics computed during training or validation"""
         names = self.model.metrics_names
         if len(names) == 1:
-            print "%s: %.3f" % (names[0],metrics)
+            print ("%s: %.3f" % (names[0],metrics))
         else:
             for name, metric in zip( names, metrics ):
                 print ("{0}: {1:.3f}".format(name,metric))

--- a/mpi_learn/train/model.py
+++ b/mpi_learn/train/model.py
@@ -31,7 +31,7 @@ class ModelFromJson(ModelBuilder):
         self.filename = filename
         self.json_str = json_str
         self.weights = weights
-	self.custom_objects = custom_objects
+        self.custom_objects = custom_objects
         super(ModelFromJson, self).__init__(comm)
 
     def build_model(self):
@@ -51,7 +51,7 @@ class ModelFromJsonTF(ModelBuilder):
         self.filename = filename
         self.json_str = json_str
         self.weights = weights
-	self.custom_objects = custom_objects
+        self.custom_objects = custom_objects
         self.device = self.get_device_name(device_name)
         super(ModelFromJsonTF, self).__init__(comm)
 
@@ -66,11 +66,11 @@ class ModelFromJsonTF(ModelBuilder):
                 dev_num = int(device[3:])
                 dev_type = 'gpu'
             except ValueError:
-                print "GPU number could not be parsed from {}; using CPU".format(device)
+                print ("GPU number could not be parsed from {}; using CPU".format(device))
                 dev_num = 0
                 dev_type = 'cpu'
         else:
-            print "Please specify 'cpu' or 'gpuN' for device name"
+            print ("Please specify 'cpu' or 'gpuN' for device name")
             dev_num = 0
             dev_type = 'cpu'
         return get_device_name(dev_type, dev_num, backend='tensorflow')


### PR DESCRIPTION
In MPIDriver.py
`#!/usr/bin/env python3`
is to make mpirun use python3 (on Caltech cluster)