### PR TITLE
multi-model implementation

### DIFF
--- a/mpi_learn/utils.py
+++ b/mpi_learn/utils.py
@@ -57,8 +57,30 @@ def load_model(filename=None, json_str=None, weights_file=None, custom_objects={
     if filename != None:
         with open( filename ) as arch_f:
             json_str = arch_f.readline()
-    model = model_from_json( json_str, custom_objects=custom_objects) 
-    if weights_file is not None:
-        model.load_weights( weights_file )
+
+    _arch = json.loads(json_str)
+    if type(_arch) == list:
+        model = []
+        if type(custom_objects)!=list:
+            print ("this is not going to work")
+            raise Exception("custom object needs to be a list if multiple models are to be created")
+        if type(weights_file)!=list:
+            print ("this is not going to work")
+            raise Exception("weights file needs to be a list if multiple models are to be created")
+        
+        if custom_objects == None:
+            custom_objects = [None]*len(_arch)
+        if weights_file == None:
+            weights_file = [None]*len(_arch)
+        for jso,co,wf in zip(_arch,custom_objects,weights_file):
+            js_str = json.dumps(jso)
+            model.append( model_from_json( js_str, custom_objects=co ))
+            if wf:
+                model[-1].load_weights( wf )
+        model = list(model) ## cast into a list
+    else:
+        model = model_from_json( json_str, custom_objects=custom_objects) 
+        if weights_file is not None:
+            model.load_weights( weights_file )
     return model
 


### PR DESCRIPTION
this is work on-going, **not to be merged**
I have second thoughts on the feasibility without changing too many parts.
@duanders if you have suggestions ; for gans, one need to have model being a list models (generator, discriminator, combined) and my first approach was to provide initialization and handling of model = [model1,model2]. but that seems cumbersome.

I am now thinking that we should have an MPIModel class that has the necessary methods, which one can wire to a simple model, or multiple ones ; I'll work out a prototype in another branch.