### PR TITLE
Checkpointing

### DIFF
--- a/MPIDriver.py
+++ b/MPIDriver.py
@@ -97,7 +97,10 @@ if __name__ == '__main__':
 
     if args.restore:
         args.restore = re.sub(r'\.algo$', '', args.restore)
-        if not args.tf:
+        if os.path.isfile(args.restore + '.latest'):
+            with open(args.restore + '.latest', 'r') as latest:
+                args.restore = latest.read().splitlines()[-1]
+        if not args.tf and os.path.isfile(args.restore + '.model'):
             model_weights = args.restore + '.model'
 
     # Theano is the default backend; use tensorflow if --tf is specified.

--- a/MPIDriver.py
+++ b/MPIDriver.py
@@ -78,6 +78,8 @@ if __name__ == '__main__':
     parser.add_argument('--gem-momentum',help='momentum for GEM',type=float, default=0.9, dest='gem_momentum')
     parser.add_argument('--gem-kappa',help='Proxy amplification parameter for GEM',type=float, default=2.0, dest='gem_kappa')
     parser.add_argument('--restore', help='pass a file to retore the variables from', default=None)
+    parser.add_argument('--checkpoint', help='Base name of the checkpointing file. If omitted no checkpointing will be done', default=None)
+    parser.add_argument('--checkpoint-interval', help='Number of epochs between checkpoints', default=5, type=int, dest='checkpoint_interval')
 
     args = parser.parse_args()
     model_name = os.path.basename(args.model_json).replace('.json','')
@@ -196,7 +198,8 @@ if __name__ == '__main__':
                           verbose=args.verbose, monitor=args.monitor,
                           early_stopping=args.early_stopping,
                           target_metric=args.target_metric,
-                          thread_validation = args.thread_validation)
+                          thread_validation = args.thread_validation,
+                          checkpoint=args.checkpoint, checkpoint_interval=args.checkpoint_interval)
 
 
     # Process 0 launches the training procedure

--- a/mpi_learn/mpi/manager.py
+++ b/mpi_learn/mpi/manager.py
@@ -284,8 +284,8 @@ class MPIManager(object):
                                         monitor=self.monitor,
                                         custom_objects=self.custom_objects,
                                         early_stopping = self.early_stopping,
-                                        target_metric = self.target_metric
-                                        )
+                                        target_metric = self.target_metric,
+                                        checkpoint=self.checkpoint, checkpoint_interval=self.checkpoint_interval)
 
 
     def figure_of_merit(self):

--- a/mpi_learn/mpi/manager.py
+++ b/mpi_learn/mpi/manager.py
@@ -115,7 +115,8 @@ class MPIManager(object):
 
     def __init__(self, comm, data, algo, model_builder, num_epochs, train_list, 
                  val_list, num_masters=1, num_processes=1, synchronous=False,
-                 verbose=False, custom_objects={}, early_stopping=None,target_metric=None, monitor=False, thread_validation=False):
+                 verbose=False, custom_objects={}, early_stopping=None,target_metric=None,
+                 monitor=False, thread_validation=False, checkpoint=None, checkpoint_interval=5):
         """Create MPI communicator(s) needed for training, and create worker 
             or master object as appropriate.
 
@@ -162,6 +163,8 @@ class MPIManager(object):
         self.early_stopping = early_stopping
         self.target_metric = target_metric
         self.thread_validation = thread_validation
+        self.checkpoint = checkpoint
+        self.checkpoint_interval = checkpoint_interval
         self.make_comms(comm)
 
     def make_comms(self,comm):
@@ -254,7 +257,8 @@ class MPIManager(object):
                                         num_sync_workers=num_sync_workers,
                                         verbose=self.verbose, custom_objects=self.custom_objects,
                                         early_stopping = self.early_stopping, target_metric = self.target_metric,
-                                        threaded_validation = self.thread_validation
+                                        threaded_validation = self.thread_validation,
+                                        checkpoint=self.checkpoint, checkpoint_interval=self.checkpoint_interval
                 )
             else:
                 self.set_train_data()
@@ -266,7 +270,9 @@ class MPIManager(object):
                                         num_epochs=self.num_epochs,
                                         verbose=self.verbose,
                                         monitor=self.monitor,
-                                        custom_objects=self.custom_objects)
+                                        custom_objects=self.custom_objects,
+                                        checkpoint=self.checkpoint, checkpoint_interval=self.checkpoint_interval
+                )
         else: #Single Process mode
             from .single_process import MPISingleWorker
             self.set_val_data()
@@ -409,7 +415,8 @@ class MPIKFoldManager(MPIManager):
                   synchronous=False,
                   verbose=False, custom_objects={},
                   early_stopping=None,target_metric=None,
-                  monitor=False):
+                  monitor=False,
+                  checkpoint=None, checkpoint_interval=5):
         self.comm_world = comm
         self.comm_fold = None
         self.fold_num = None
@@ -420,7 +427,8 @@ class MPIKFoldManager(MPIManager):
                                       synchronous,
                                       verbose, custom_objects,
                                       early_stopping,target_metric,
-                                      monitor)
+                                      monitor,
+                                      checkpoint=checkpoint, checkpoint_interval=checkpoint_interval)
             return
         
         if int(comm.Get_size() / float(NFolds))<=1:
@@ -447,7 +455,8 @@ class MPIKFoldManager(MPIManager):
                                   val_list_on_fold, num_masters,num_process,
                                   synchronous,
                                   verbose, custom_objects,
-                                  early_stopping,target_metric,monitor)
+                                  early_stopping,target_metric,monitor,
+                                  checkpoint=checkpoint, checkpoint_interval=checkpoint_interval)
 
     def free_comms(self):
         self.manager.free_comms()

--- a/mpi_learn/mpi/process.py
+++ b/mpi_learn/mpi/process.py
@@ -129,7 +129,18 @@ class MPIProcess(object):
         """to be implemented by the specific process
         """
         pass
-    
+
+    def save_checkpoint(self):
+        if self.checkpoint is not None and self.epoch % self.checkpoint_interval == 0:
+            file_name = '{}-{}'.format(self.checkpoint, self.epoch)
+            if self.model:
+                self.model.save(file_name + '.model')
+            if self.algo:
+                self.algo.save(file_name + '.algo')
+
+            with open(self.checkpoint + '.latest', 'w') as latest:
+                latest.write(file_name)
+
     def history_key(self):
         #return str(self.rank)
         return self.ranks
@@ -861,17 +872,6 @@ class MPIMaster(MPIProcess):
         self.data.finalize()
         self.stop_time = time.time()
         Trace.end("train")
-
-    def save_checkpoint(self):
-        if self.checkpoint is not None and self.epoch % self.checkpoint_interval == 0:
-            file_name = '{}-{}'.format(self.checkpoint, self.epoch)
-            if self.model:
-                self.model.save(file_name + '.model')
-            if self.algo:
-                self.algo.save(file_name + '.algo')
-
-            with open(self.checkpoint + '.latest', 'w') as latest:
-                latest.write(file_name)
 
     def record_details(self, json_name=None, meta=None):
         ## for the uber master, save yourself

--- a/mpi_learn/train/algo.py
+++ b/mpi_learn/train/algo.py
@@ -1,5 +1,5 @@
 ### Algo class
-
+import os
 import numpy as np
 from ast import literal_eval
 from .optimizer import get_optimizer, MultiOptimizer, OptimizerBuilder
@@ -76,6 +76,9 @@ class Algo(object):
         else:
             self.worker_update_type = 'update'
             self.send_before_apply = False
+
+        # Keep track if internal state was restored
+        self.restore = False
 
     def reset(self):
         ## reset any caching running values
@@ -165,4 +168,13 @@ class Algo(object):
             self.optimizer.save(fn)
 
     def load(self, fn):
-        self.optimizer = self.optimizer.load(fn)
+        if os.path.isfile(fn + '.latest'):
+            with open(fn + '.latest', 'r') as latest:
+                fn = latest.read().splitlines()[-1]
+        new_optimizer = self.optimizer.load(fn)
+        if new_optimizer is not None:
+            print("Restored state from {}".format(fn))
+            self.optimizer = new_optimizer
+            self.restore = True
+        else:
+            print("Failed to restore state from {}, starting srom scratch".format(fn))

--- a/mpi_learn/train/algo.py
+++ b/mpi_learn/train/algo.py
@@ -168,9 +168,6 @@ class Algo(object):
             self.optimizer.save(fn)
 
     def load(self, fn):
-        if os.path.isfile(fn + '.latest'):
-            with open(fn + '.latest', 'r') as latest:
-                fn = latest.read().splitlines()[-1]
         new_optimizer = self.optimizer.load(fn)
         if new_optimizer is not None:
             print("Restored state from {}".format(fn))

--- a/mpi_learn/train/optimizer.py
+++ b/mpi_learn/train/optimizer.py
@@ -31,9 +31,12 @@ class Optimizer(object):
     def load(self, fn = 'algo_.pkl'):
         if not fn.endswith('.algo'):
             fn = fn + '.algo'
-        d = open(fn, 'rb')
-        new_self = pickle.load( d )
-        d.close()
+        try:
+            d = open(fn, 'rb')
+            new_self = pickle.load( d )
+            d.close()
+        except:
+            new_self = None
         return new_self
 
 class MultiOptimizer(Optimizer):
@@ -334,7 +337,7 @@ class TFOptimizer(Optimizer):
             name='optimizer_op' # We may need to create uniqie name
         )
 
-        self.saver = tf.train.Saver(max_to_keep=1)
+        self.saver = tf.train.Saver(max_to_keep=None)
 
         if self.load_fn:
             self.saver.restore(self.sess, self.load_fn)
@@ -342,10 +345,13 @@ class TFOptimizer(Optimizer):
             self.sess.run(tf.global_variables_initializer())
 
     def load(self, fn='train_history'):
-        self.load_fn = re.sub(r'\.algo$', '', fn)
-        self.do_reset = True
-
-        return self
+        load_fn = re.sub(r'\.algo$', '', fn)
+        if os.path.isfile(load_fn + '.meta'):
+            self.load_fn = load_fn
+            self.do_reset = True
+            return self
+        else:
+            return None
 
     def apply_update(self, weights, gradient):
         if self.do_reset:


### PR DESCRIPTION
This adds `--checkpoint` configuration parameter to periodically save state. There are now two relevant runtime arguments, `--restore <name>` and `--checkpoint <name>`.

If `--restore` is omitted, training starts from scratch, regardless of the existence of any checkpoint files. If `--restore` is present, an attempt to load from it will be made. If successful, great, if not, start from scratch.

Checkpoints will keep track of what the latest checkpoint is, in `<name>.latest`. if `<name>` in `--restore` matches an existing set of checkpoints (i.e., there is a `<name>.latest`), that will be used as a starting point. If `<name>.latest` does not exist, then it is the regular case.

In case of a state restored from a checkpoint, the training will run for the reduced number of epochs.