### PR TITLE
Introduce logging, clean-up the print statements, and more

### DIFF
--- a/mpi_learn/logger.py
+++ b/mpi_learn/logger.py
@@ -1,0 +1,104 @@
+from mpi4py import MPI
+import time
+import logging
+from os.path import abspath
+
+level_map = {
+    'debug': logging.DEBUG,
+    'info': logging.INFO,
+    'warn': logging.WARNING,
+    'error': logging.ERROR,
+}
+
+base_prefix = "{ptype} {world}:{parent}:{process}"
+file_handler = None
+stream_handler = None
+
+start_time = time.time()
+
+class ElapsedTimeFormatter(logging.Formatter):
+    def formatTime(self, record, datefmt=None):
+        global start_time
+        total_millis = int(record.created - start_time) * 1000 + int(record.msecs)
+        
+        millis = total_millis%1000
+        millis = int(millis)
+        seconds=(total_millis/1000)%60
+        seconds = int(seconds)
+        minutes=(total_millis/(1000*60))%60
+        minutes = int(minutes)
+        hours=(total_millis/(1000*60*60))%24
+        hours = int(hours)
+
+        elapsed = "{:04d}:{:02d}:{:02d}.{:03d}".format(hours, minutes, seconds, millis)
+        return elapsed
+
+class MPIFileHandler(logging.FileHandler):
+    def __init__(self,
+                 filename,
+                 mode=MPI.MODE_WRONLY|MPI.MODE_CREATE|MPI.MODE_APPEND ,
+                 encoding='utf-8',
+                 delay=False,
+                 comm=MPI.COMM_WORLD):
+        self.baseFilename = abspath(filename)
+        self.mode = mode
+        self.encoding = encoding
+        self.comm = comm.Dup()
+        if delay:
+            #We don't open the stream, but we still need to call the
+            #Handler constructor to set level, formatter, lock etc.
+            logging.Handler.__init__(self)
+            self.stream = None
+        else:
+           logging.StreamHandler.__init__(self, self._open())
+
+    def _open(self):
+        stream = MPI.File.Open( self.comm, self.baseFilename, self.mode )
+        stream.Set_atomicity(True)
+        return stream
+
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            stream = self.stream
+            stream.Write_shared((msg+self.terminator).encode(self.encoding))
+            #self.flush()
+        except Exception:
+            self.handleError(record)
+
+    def close(self):
+        if self.stream:
+            self.stream.Sync()
+            self.stream.Close()
+            self.stream = None
+
+def initialize_logger(filename=None, file_level='info', stream=True, stream_level='info'):
+    global file_handler
+    global stream_handler
+    level = get_log_level(file_level)
+    logger = logging.getLogger()
+    logger.setLevel(level)
+    if filename is not None:
+        file_handler = MPIFileHandler(filename)
+        logger.addHandler(file_handler)
+    if stream:
+        stream_handler = logging.StreamHandler()
+        logger.addHandler(stream_handler)
+    set_logging_prefix(MPI.COMM_WORLD.rank)
+
+def get_log_level(levelstr='info'):
+    levelstr = levelstr.lower()
+    return level_map[levelstr]
+
+def set_logging_prefix(world_rank, parent_rank='-', process_rank='-', process_type='P'):
+    global file_handler
+    global stream_handler
+    prefix = base_prefix.format(ptype=process_type, world=world_rank, parent=parent_rank, process=process_rank)
+    formatter = ElapsedTimeFormatter('%(asctime)s ' + prefix + ' [%(levelname)s] %(message)s')
+    if file_handler is not None:
+        file_handler.setFormatter(formatter)
+    if stream_handler is not None:
+        stream_handler.setFormatter(formatter)
+
+def get_logger():
+    return logging.getLogger()

--- a/mpi_learn/mpi/single_process.py
+++ b/mpi_learn/mpi/single_process.py
@@ -2,6 +2,7 @@ import os,sys,json
 import numpy as np
 import socket
 import time
+import logging
 
 from ..train.monitor import Monitor
 from ..utils import Error, weights_from_shapes, shapes_from_weights
@@ -28,7 +29,7 @@ class MPISingleWorker(MPIWorker):
         self.check_sanity()
 
         for epoch in range(1, self.num_epochs + 1):
-            print ("MPISingle {0} beginning epoch {1:d}".format(self.ranks, self.epoch + epoch))
+            logging.info("beginning epoch {:d}".format(self.epoch + epoch))
             if self.monitor:
                 self.monitor.start_monitor()
             epoch_metrics = np.zeros((1,))
@@ -60,7 +61,7 @@ class MPISingleWorker(MPIWorker):
             self.validate()
             self.save_checkpoint()
 
-        print ("MPISingle {0} signing off".format(self.ranks))
+        logging.info("Signing off")
         if self.monitor:
             self.update_monitor( self.monitor.get_stats() )        
 

--- a/mpi_learn/train/monitor.py
+++ b/mpi_learn/train/monitor.py
@@ -1,12 +1,13 @@
 ### Monitor class
 
 import os
+import logging
 from threading import Thread
 import psutil
 try:
     import pynvml
 except:
-    print ("pynvml does not load, not monitoring available")
+    logging.warning("pynvml does not load, no monitoring available")
 import time
 
 class Monitor(object):

--- a/mpi_learn/utils.py
+++ b/mpi_learn/utils.py
@@ -1,6 +1,8 @@
 ### Utilities for mpi_learn module
-
+import os
+import sys
 import numpy as np
+import logging
 
 class Error(Exception):
     pass
@@ -15,11 +17,11 @@ def shapes_from_weights(weights):
 
 def get_num_gpus():
     """Returns the number of GPUs available"""
-    print ("Determining number of GPUs...")
+    logging.debug("Determining number of GPUs...")
     from pycuda import driver 
     driver.init()
     num_gpus = driver.Device.count()
-    print ("Number of GPUs: {}".format(num_gpus))
+    logging.debug("Number of GPUs: {}".format(num_gpus))
     return num_gpus
 
 def get_device_name(dev_type, dev_num, backend='theano'):
@@ -39,13 +41,16 @@ def import_keras(tries=10):
         as a workaround, just try several times to import keras."""
     for try_num in range(tries):
         try:
+            stderr = sys.stderr
+            sys.stderr = open(os.devnull, 'w')
             import keras
+            sys.stderr = stderr
             return
         except ValueError:
-            print ("Unable to import keras. Trying again: {0:d}".format(try_num))
+            logging.warning("Unable to import keras. Trying again: {0:d}".format(try_num))
             from time import sleep
             sleep(0.1)
-    print ("Failed to import keras!")
+    logging.error("Failed to import keras!")
 
 def load_model(filename=None, model=None, weights_file=None, custom_objects={}):
     """Loads model architecture from JSON and instantiates the model.


### PR DESCRIPTION
Use MPI-aware logging. As part of all log messages, a type of process (master, worker) and rank (within world, parent, child) are recorded.

Note to testers: Since this writes on NFS from MPI, there might be issues with locking during `MPI_File_open`. In that case, just point the log file to some regular partition (like /tmp)