### PR TITLE
Add channel ordering option + fix for k2 bug

### DIFF
--- a/MPIGDriver.py
+++ b/MPIGDriver.py
@@ -156,7 +156,7 @@ if __name__ == '__main__':
                 mode='easgd', sync_every=args.sync_every,
                 worker_optimizer=args.worker_optimizer,
                 worker_optimizer_params=args.worker_optimizer_params,
-                elastic_force=args.elastic_force/(comm.Get_size()-1),
+                elastic_force=args.elastic_force/(min(1,comm.Get_size()-1)),
                 elastic_lr=args.elastic_lr, 
                 elastic_momentum=args.elastic_momentum) 
     else:

--- a/models/get_3d.py
+++ b/models/get_3d.py
@@ -7,7 +7,7 @@ except:
     print ("hum")
 import numpy as np
 import sys
-
+import keras
 def get_data(datafile):
     #get data for training
     #print ('Loading Data from .....', datafile)
@@ -20,7 +20,11 @@ def get_data(datafile):
     X = X.astype(np.float32)
     y = y.astype(np.float32)
     y = y/100.
-    ecal = np.squeeze(np.sum(X, axis=(1, 2, 3)))
+    if keras.backend.image_data_format() !='channels_last':
+       X =np.moveaxis(X, -1, 1)
+       ecal = np.squeeze(np.sum(X, axis=(2, 3, 4)))
+    else:
+       ecal = np.squeeze(np.sum(X, axis=(1, 2, 3)))
     print (X.shape)
     print (y.shape)
     print (ecal.shape)


### PR DESCRIPTION
Introduces the check on the keras image data format flag to set the best channels ordering according to the hardware architecture:  channels_first for CPU and channels_last for GPU